### PR TITLE
fix alignment of canvas and background image on Firefox

### DIFF
--- a/master.css
+++ b/master.css
@@ -51,6 +51,7 @@
 }
 
 .background-img {
+  position: absolute;
   z-index: -99;
   width: 100%;
   height: 100%;


### PR DESCRIPTION
A single line of CSS, and it's Firefox-compatible.  Otherwise, the action takes place 100% to the right, off-screen.
