### PR TITLE
add absolute positioning to background image, for Firefox compatibility

### DIFF
--- a/master.css
+++ b/master.css
@@ -51,6 +51,7 @@
 }
 
 .background-img {
+  position: absolute;
   z-index: -99;
   width: 100%;
   height: 100%;


### PR DESCRIPTION
Without this attribute, canvas appears 100% to the right in Firefox.

The gh-pages branch should be updated to match master after this, for it to have an effect on the live demo.
